### PR TITLE
isInteger updates

### DIFF
--- a/differint/differint.py
+++ b/differint/differint.py
@@ -3,7 +3,9 @@ from __future__ import print_function
 import numpy as np
 
 def isInteger(n):
-    if n >= 0 and (type(n) is type(0)):
+    if n.imag:
+        return False
+    if float(n.real).is_integer():
         return True
     else:
         return False

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -10,6 +10,9 @@ def isInteger(n):
     else:
         return False
 
+def isPositiveInteger(n):
+    return isInteger(n) and n > 0
+
 def checkValues(alpha, domain_start, domain_end, num_points):
     """ Type checking for valid inputs. """
     
@@ -46,7 +49,7 @@ def poch(a,n):
     
     # First, check if 'a' is a real number (this is currently only working for reals).
     assert type(a) is not type(1+1j), "a must be real: %r" % a
-    isInteger(n)
+    isPositiveInteger(n)
     
     # Compute the Pochhammer symbol.
     if n == 0:
@@ -125,7 +128,7 @@ def Gamma(z):
     
     if type(zz) == 'complex':
         return f.astype(complex)
-    elif isInteger(zz):
+    elif isPositiveInteger(zz):
         f = np.round(f)
         return f.astype(int)
     else:
@@ -144,7 +147,7 @@ def GLcoeffs(alpha,n):
     """ 
     
     # Validate input.
-    isInteger(n)
+    isPositiveInteger(n)
     
     # Get generalized binomial coefficients.
     GL_filter = np.zeros(n+1,)

--- a/tests/test.py
+++ b/tests/test.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 
 # Import from sibling directory.
-from ..differint.differint import *
+from differint.differint import *
 
 # Define constants to be used in tests.
 poch_first_argument = 1
@@ -38,7 +38,16 @@ class HelperTestCases(unittest.TestCase):
     
     def test_isInteger(self):
         self.assertTrue(isInteger(1))
+        self.assertTrue(isInteger(1.0))
+        self.assertTrue(isInteger(1+0j))
         self.assertFalse(isInteger(1.1))
+        self.assertFalse(isInteger(1.1+0j))
+        self.assertFalse(isInteger(1+1j))
+
+    def test_isPositiveInteger(self):
+        self.assertTrue(isPositiveInteger(1))
+        self.assertFalse(isPositiveInteger(1.1))
+        self.assertFalse(isPositiveInteger(-1))
     
     def test_pochhammer(self):
         self.assertEqual(poch(poch_first_argument, poch_second_argument), poch_true_answer)


### PR DESCRIPTION
Currently, the `isInteger` function doesn't support checking complex numbers. This creates errors when calling the `Gamma` function with a complex number. I have added in logic to return `False` if the number has a non-zero imaginary part, and otherwise to return `True` if the number has a no decimal part.

There is also a check in `isInteger` to see if the number is non-negative. This is not implied in the function's name. I have moved this into a separate function `isPositiveInteger`, and updated references to `isInteger` to this new function.

I have run all tests, including one new test for the new `isInteger` function, and an updated test for the `isPositiveInteger` function. All tests pass on my Windows 10 computer.