### PR TITLE
Pochhammer compatibility

### DIFF
--- a/differint/differint.py
+++ b/differint/differint.py
@@ -50,6 +50,7 @@ def poch(a,n):
     """
     if isPositiveInteger(n):
         # Compute the Pochhammer symbol.
+        n = int(n)
         if n == 0:
             return 1.0
         else:

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -45,20 +45,25 @@ def functionCheck(f_name, domain_start, domain_end, num_points):
     return f_values, step_size
 
 def poch(a,n):
-    """ Returns the Pochhammer symbol (a)_n. """
-    
-    # First, check if 'a' is a real number (this is currently only working for reals).
-    assert type(a) is not type(1+1j), "a must be real: %r" % a
-    isPositiveInteger(n)
-    
-    # Compute the Pochhammer symbol.
-    if n == 0:
-        return 1.0
-    else:
-        poch = 1
-        for j in range(n):
-            poch *= (a + j)
-        return poch
+    """ Returns the Pochhammer symbol (a)_n. a can be any complex or real number 
+        except the negative integers and 0. n can be any nonnegative real.
+    """
+    if isPositiveInteger(n):
+        # Compute the Pochhammer symbol.
+        if n == 0:
+            return 1.0
+        else:
+            poch = 1
+            for j in range(n):
+                poch *= (a + j)
+            return poch
+
+    # if a and a + n are both nonpositive integers, we can use another formula...
+    # see here https://www.mathworks.com/help/symbolic/sym.pochhammer.html
+    if isPositiveInteger(-1 * a) and isPositiveInteger(-1 * a - n):
+        sign = -1 if np.abs(n % 2) == 1 else 1
+        return sign * Gamma(1 - a) / Gamma(1 - a - n)
+    return Gamma(a + n) / Gamma(a)
     
 def Gamma(z):
     """ Paul Godfrey's Gamma function implementation valid for z complex.

--- a/tests/test.py
+++ b/tests/test.py
@@ -51,6 +51,10 @@ class HelperTestCases(unittest.TestCase):
     
     def test_pochhammer(self):
         self.assertEqual(poch(poch_first_argument, poch_second_argument), poch_true_answer)
+        self.assertEqual(poch(-1, 3), 0)
+        self.assertEqual(poch(-1.5, 0.5), np.inf)
+        self.assertEqual(np.round(poch(1j, 1), 3), 0.000+1.000j)
+        self.assertEqual(poch(-10, 2), 90)
         
     def test_functionCheck(self):
         self.assertEqual(len(checked_function1), test_N)

--- a/tests/test.py
+++ b/tests/test.py
@@ -86,6 +86,9 @@ class HelperTestCases(unittest.TestCase):
         
     def testRealValue(self):
         self.assertEqual(Gamma(1.25),0.9064024770554769)
+
+    def testComplexValue(self):
+        self.assertEqual(np.round(Gamma(1j), 4), -0.1549-0.498j)
         
 class TestInterpolantCoefficients(unittest.TestCase):
     """ Test the correctness of the interpolant coefficients. """


### PR DESCRIPTION
The current implementation of `poch` only supports `a` in the reals (except non-positive integers) and `n` in the natural numbers. I have added support for complex a, real n, and cases where `a` is a non-positive integer and where `a+n` is a non-positive integer.

I have also added tests for these new use cases, and all tests pass on my Windows 10 machine.