### PR TITLE
Gamma speedup

### DIFF
--- a/differint/differint.py
+++ b/differint/differint.py
@@ -73,7 +73,12 @@ def Gamma(z):
         15 significant digits of accuracy for real z and 13
         significant digits for other values.
     """
-    
+    if not (type(z) == type(1+1j)):
+        if isPositiveInteger(-1 * z):
+            return np.inf
+        from math import gamma
+        return gamma(z)
+
     siz = np.size(z)
     zz = z
     f = np.zeros(2,)

--- a/tests/test.py
+++ b/tests/test.py
@@ -85,7 +85,7 @@ class HelperTestCases(unittest.TestCase):
         self.assertEqual(Gamma(-2),np.inf)
         
     def testRealValue(self):
-        self.assertEqual(Gamma(1.25),0.9064024770554769)
+        self.assertEqual(np.round(Gamma(1.25), 12), 0.906402477055)
 
     def testComplexValue(self):
         self.assertEqual(np.round(Gamma(1j), 4), -0.1549-0.498j)


### PR DESCRIPTION
The current implementation of the gamma function is slower than `scipy.gamma` and `math.gamma`. 
![image](https://user-images.githubusercontent.com/47254427/201548680-6fabc048-6eb7-43a8-97cb-c649e6c239d6.png)
Above is a plot of the runtime of all three of those functions on a list of values given by `np.arange(0.5, 100, 0.5)`. 
![image](https://user-images.githubusercontent.com/47254427/201548805-c3f923d2-bb3c-491f-bd2b-31634fffb7ae.png)
Above is the same plot, but for the values `np.arange(0.5, 100, 0.5) * 1j`. `math.gamma` doesn't support complex values, so I just set the y-values for that case to 0 out of laziness. 

To avoid adding scipy as a dependency, I propose calling `math.gamma` when calculating it for a real value, and the current `Gamma` function for any complex values. This way there will be a speed up for a large proportion of use cases.

Here's the runtimes after doing so for real and imaginary numbers respectively...
![Figure_1](https://user-images.githubusercontent.com/47254427/201549150-571c9b85-bafb-453f-93a7-2fcc32033651.png)

I also updated the gamma function test to reduce the precision slightly, as different floating point errors caused it to fail. If more than 12 digit precision is required, maybe an argument to prefer the `Gamma` implementation could be used...

Everything was timed using timeit with `number=1000` on my Windows 10 computer with an Intel i7-7700HQ.

I know the slower runtime may not be causing any major problems overall, but it's an easy fix to get the run time an order of magnitude faster in most cases.

Also, this already has the changes from the pochhammer_compatibilty branch merged in... 