### PR TITLE
Caputo L-methods

### DIFF
--- a/differint/differint.py
+++ b/differint/differint.py
@@ -614,25 +614,14 @@ def CaputoL2Cpoint(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
     checkValues(alpha, domain_start, domain_end, num_points)
     f_values, step_size = functionCheck(f_name, domain_start, domain_end, num_points)
 
-    def a_coes(l, alpha):
-        sigma = 1-alpha/2
-        if l == 0:
-            return sigma**(1-alpha)
-        return (l + sigma)**(1-alpha) - (l-1+sigma)**(1-alpha)
-    def b_coes(l, alpha):
-        sigma = 1-alpha/2
-        return (1/(2-alpha))*((l+sigma)**(2-alpha) - (l-1+sigma)**(2-alpha)) - \
-                0.5 * ((l + sigma)**(1-alpha) + (l-1+sigma)**(1-alpha))
-    def c_coes(k, alpha, n):
-        if k == 0:
-            return a_coes(0, alpha) + b_coes(1, alpha)
-        elif 1 <= k and k <= n-2:
-            return a_coes(k, alpha) + b_coes(k+1, alpha) - b_coes(k, alpha)
-        elif k == n-1:
-            return a_coes(k, alpha) - b_coes(k, alpha)
-    L2C = 0
-    for k in range(0, num_points - 2):
-        L2C += c_coes(k, alpha, num_points-1) * (f_values[num_points - k - 1]-f_values[num_points - k - 2])
-    L2C *= (step_size**(-alpha)) / Gamma(2-alpha)
+    def b_coes(alpha, j):
+        return (j + 1) ** (2 - alpha) - j ** (2 - alpha)
+
+    # start with the points outside of the domain
+    L2C = b_coes(alpha, 0) * (f_values[num_points - 3] - f_values[num_points - 2] - f_values[num_points - 1] + f_name(num_points * step_size)) #f_name(num_points * step_size)
+    L2C += b_coes(alpha, num_points - 2) * (f_name(-1 * step_size) + f_values[2] - f_values[1] - f_values[0])
+    for k in range(1, num_points - 2):
+        L2C += b_coes(alpha, k) * (f_values[num_points - 3 - k] - f_values[num_points - k - 2] - f_values[num_points - k - 1] + f_values[num_points - k]) 
+    L2C *= step_size ** (-1 * alpha) / Gamma(3 - alpha) * 0.5
 
     return L2C

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -493,7 +493,7 @@ def CaputoL1point(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
     Parameters
     ==========
         alpha : float
-            The order of the differintegral to be computed.
+            The order of the differintegral to be computed. Must be in (0, 1)
         f_name : function handle, lambda function, list, or 1d-array of 
                  function values
             This is the function that is to be differintegrated.
@@ -532,6 +532,9 @@ def CaputoL1point(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
 
 def CaputoL2Cpoint(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
     ''' Calculate the Caputo derivative of a function at a point using the L2C method.
+        A note: this method requires evaluation of the points f(domain_end + step size)
+        and f(-step_size), and currently will only work if `f_name` is a callable 
+        function.
 
     see Karniadakis, G.E.. (2019). Handbook of Fractional Calculus with Applications
     Volume 3: Numerical Methods. De Gruyter.
@@ -539,9 +542,8 @@ def CaputoL2Cpoint(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
     Parameters
     ==========
         alpha : float
-            The order of the differintegral to be computed.
-        f_name : function handle, lambda function, list, or 1d-array of 
-                 function values
+            The order of the differintegral to be computed. Must be in (0, 2).
+        f_name : function handle or lambda function
             This is the function that is to be differintegrated.
         domain_start : float
             The left-endpoint of the function domain. Default value is 0.
@@ -555,8 +557,8 @@ def CaputoL2Cpoint(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
         L2C : float
             The Caputo L2C integral evaluated at the corresponding point.
     '''
-    if alpha <= 0 or alpha >= 1:
-        raise ValueError('Alpha must be in (0, 1) for this method.')
+    if alpha <= 0 or alpha >= 2:
+        raise ValueError('Alpha must be in (0, 1) or (1, 2) for this method.')
 
     # Flip the domain limits if they are in the wrong order.
     if domain_start > domain_end:

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -530,6 +530,52 @@ def CaputoL1point(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
     
     return L1
 
+def CaputoL2point(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
+    ''' Calculate the Caputo derivative of a function at a point using the L2 method.
+        A note: this method requires evaluation of the point f(domain_end + step size),
+        and currently will only work if `f_name` is a callable function.
+
+    see Karniadakis, G.E.. (2019). Handbook of Fractional Calculus with Applications
+    Volume 3: Numerical Methods. De Gruyter.
+
+    Parameters
+    ==========
+        alpha : float
+            The order of the differintegral to be computed. Must be in (1, 2).
+        f_name : function handle or lambda function
+            This is the function that is to be differintegrated.
+        domain_start : float
+            The left-endpoint of the function domain. Default value is 0.
+        domain_end : float
+            The right-endpoint of the function domain; the point at which the 
+            differintegral is being evaluated. Default value is 1.
+        num_points : integer
+            The number of points in the domain. Default value is 100.
+    Output
+    ======
+        L2 : float
+            The Caputo L2 integral evaluated at the corresponding point.
+    '''
+    if alpha <= 1 or alpha >= 2:
+        raise ValueError('Alpha must be in (1, 2) for this method.')
+    # Flip the domain limits if they are in the wrong order.
+    if domain_start > domain_end:
+        domain_start, domain_end = domain_end, domain_start
+    
+    # Check inputs.
+    checkValues(alpha, domain_start, domain_end, num_points)
+    f_values, step_size = functionCheck(f_name, domain_start, domain_end, num_points)
+
+    def b_coes(alpha, j):
+        return (j + 1) ** (2 - alpha) - j ** (2 - alpha)
+
+    # start with the point outside of the domain
+    L2 = b_coes(alpha, 0) * (f_values[num_points - 2] + f_name(num_points * step_size) - 2 * f_values[num_points - 1]) #f_name(num_points * step_size)
+    for k in range(1, num_points - 2):
+        L2 += b_coes(alpha, k) * (f_values[num_points - 2 - k] + f_values[num_points - k] - 2 * f_values[num_points - k - 1])
+    return L2 * step_size ** (-1 * alpha) / Gamma(3 - alpha)
+
+
 def CaputoL2Cpoint(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
     ''' Calculate the Caputo derivative of a function at a point using the L2C method.
         A note: this method requires evaluation of the points f(domain_end + step size)

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -529,3 +529,38 @@ def CaputoL1point(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
     L1 = 1 / Gamma(2 - alpha) * np.sum(np.multiply(coefficients * step_size**(-alpha), f_differences))
     
     return L1
+
+def CaputoL2Cpoint(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
+    if alpha <= 0 or alpha >= 1:
+        raise ValueError('Alpha must be in (0, 1) for this method.')
+
+    # Flip the domain limits if they are in the wrong order.
+    if domain_start > domain_end:
+        domain_start, domain_end = domain_end, domain_start
+    
+    # Check inputs.
+    checkValues(alpha, domain_start, domain_end, num_points)
+    f_values, step_size = functionCheck(f_name, domain_start, domain_end, num_points)
+
+    def a_coes(l, alpha):
+        sigma = 1-alpha/2
+        if l == 0:
+            return sigma**(1-alpha)
+        return (l + sigma)**(1-alpha) - (l-1+sigma)**(1-alpha)
+    def b_coes(l, alpha):
+        sigma = 1-alpha/2
+        return (1/(2-alpha))*((l+sigma)**(2-alpha) - (l-1+sigma)**(2-alpha)) - \
+                0.5 * ((l + sigma)**(1-alpha) + (l-1+sigma)**(1-alpha))
+    def c_coes(k, alpha, n):
+        if k == 0:
+            return a_coes(0, alpha) + b_coes(1, alpha)
+        elif 1 <= k and k <= n-2:
+            return a_coes(k, alpha) + b_coes(k+1, alpha) - b_coes(k, alpha)
+        elif k == n-1:
+            return a_coes(k, alpha) - b_coes(k, alpha)
+    L2C = 0
+    for k in range(0, num_points - 2):
+        L2C += c_coes(k, alpha, num_points-1) * (f_values[num_points - k - 1]-f_values[num_points - k - 2])
+    L2C *= (step_size**(-alpha)) / Gamma(2-alpha)
+
+    return L2C

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -625,3 +625,52 @@ def CaputoL2Cpoint(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
     L2C *= step_size ** (-1 * alpha) / Gamma(3 - alpha) * 0.5
 
     return L2C
+
+def CaputoFromRLpoint(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
+    ''' Calculate the Caputo derivative of a function at a point using the conversion
+        formula from the RL differintegrals.
+
+    see Du, R., Yan, Y. and Liang, Z., (2019). A high-order scheme to
+        approximate the caputo fractional derivative and its application
+        to solve the fractional diffusion wave equation, Journal of
+        Computational Physics, 376, pp. 1312-1330
+
+    Parameters
+    ==========
+        alpha : float
+            The order of the differintegral to be computed. Must be in (1, 2).
+        f_name : function handle, lambda function, list, or 1d-array of 
+                 function values
+            This is the function that is to be differintegrated.
+        domain_start : float
+            The left-endpoint of the function domain. Default value is 0.
+        domain_end : float
+            The right-endpoint of the function domain; the point at which the 
+            differintegral is being evaluated. Default value is 1.
+        num_points : integer
+            The number of points in the domain. Default value is 100.
+    Output
+    ======
+        C : float
+            The Caputo integral evaluated at the corresponding point.
+    '''
+    if alpha <= 1 or alpha >= 2:
+        raise ValueError('Alpha must be in (1, 2) for this method.')
+
+    # Flip the domain limits if they are in the wrong order.
+    if domain_start > domain_end:
+        domain_start, domain_end = domain_end, domain_start
+    
+    # Check inputs.
+    checkValues(alpha, domain_start, domain_end, num_points)
+    f_values, step_size = functionCheck(f_name, domain_start, domain_end, num_points)
+
+    C = 0
+    C -= f_values[0] * domain_end ** (-1 * alpha) / Gamma(1 - alpha)
+    C -= (f_values[1] - f_values[0]) / step_size * domain_end ** (1 - alpha) / Gamma(2 - alpha)
+    C += RLpoint(alpha - 2, f_name, domain_start, float(domain_end + step_size), num_points) / step_size ** 2
+    C -= 2 * RLpoint(alpha - 2, f_name, domain_start, float(domain_end), num_points) / step_size ** 2
+    C -= RLpoint(alpha - 2, f_name, domain_start, float(domain_end - step_size), num_points) / step_size ** 2
+    return C
+
+

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -483,3 +483,49 @@ class GLIinterpolat:
         self.nxt = alpha*(2+alpha)/8
         self.crr = (4-alpha*alpha)/4
         self.prv = alpha*(alpha-2)/8
+
+def CaputoL1point(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
+    ''' Calculate the Caputo derivative of a function at a point using the L1 method.
+
+    see Karniadakis, G.E.. (2019). Handbook of Fractional Calculus with Applications
+    Volume 3: Numerical Methods. De Gruyter.
+
+    Parameters
+    ==========
+        alpha : float
+            The order of the differintegral to be computed.
+        f_name : function handle, lambda function, list, or 1d-array of 
+                 function values
+            This is the function that is to be differintegrated.
+        domain_start : float
+            The left-endpoint of the function domain. Default value is 0.
+        domain_end : float
+            The right-endpoint of the function domain; the point at which the 
+            differintegral is being evaluated. Default value is 1.
+        num_points : integer
+            The number of points in the domain. Default value is 100.
+    Output
+    ======
+        L1 : float
+            The Caputo L1 integral evaluated at the corresponding point.
+    '''
+
+    if alpha <= 0 or alpha >= 1:
+        raise ValueError('Alpha must be in (0, 1) for this method.')
+
+    # Flip the domain limits if they are in the wrong order.
+    if domain_start > domain_end:
+        domain_start, domain_end = domain_end, domain_start
+    
+    # Check inputs.
+    checkValues(alpha, domain_start, domain_end, num_points)
+    f_values, step_size = functionCheck(f_name, domain_start, domain_end, num_points)
+
+    f_values = np.array(f_values)
+    j_values = np.arange(0, num_points-1)
+    coefficients = (j_values + 1) ** (1 - alpha) - (j_values) ** (1 - alpha)
+    f_differences = f_values[1:] - f_values[:-1]
+    f_differences = f_differences[::-1]
+    L1 = 1 / Gamma(2 - alpha) * np.sum(np.multiply(coefficients * step_size**(-alpha), f_differences))
+    
+    return L1

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -531,6 +531,30 @@ def CaputoL1point(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
     return L1
 
 def CaputoL2Cpoint(alpha, f_name, domain_start=0, domain_end=1, num_points=100):
+    ''' Calculate the Caputo derivative of a function at a point using the L2C method.
+
+    see Karniadakis, G.E.. (2019). Handbook of Fractional Calculus with Applications
+    Volume 3: Numerical Methods. De Gruyter.
+
+    Parameters
+    ==========
+        alpha : float
+            The order of the differintegral to be computed.
+        f_name : function handle, lambda function, list, or 1d-array of 
+                 function values
+            This is the function that is to be differintegrated.
+        domain_start : float
+            The left-endpoint of the function domain. Default value is 0.
+        domain_end : float
+            The right-endpoint of the function domain; the point at which the 
+            differintegral is being evaluated. Default value is 1.
+        num_points : integer
+            The number of points in the domain. Default value is 100.
+    Output
+    ======
+        L2C : float
+            The Caputo L2C integral evaluated at the corresponding point.
+    '''
     if alpha <= 0 or alpha >= 1:
         raise ValueError('Alpha must be in (0, 1) for this method.')
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -132,6 +132,12 @@ class TestAlgorithms(unittest.TestCase):
     def test_CaputoL1point_accuracy_polynomial(self):
         self.assertTrue(abs(CaputoL1point(0.5, lambda x: x**2-1, 0, 1., 1024)-truevaluepoly_caputo) <= 1e-3)
         
+    def test_CaputoL2Cpoint_accuracy_sqrt(self):
+        self.assertTrue(abs(CaputoL2Cpoint(0.5, lambda x: x**0.5, 0, 1., 1024)-sqrtpi2) <= 1e-1)
+
+    def test_CaputoL2Cpoint_accuracy_polynomial(self):
+        self.assertTrue(abs(CaputoL2Cpoint(0.5, lambda x: x**2, 0, 1., 1024)-truevaluepoly_caputo) <= 1e-3)
+
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)
     

--- a/tests/test.py
+++ b/tests/test.py
@@ -13,6 +13,7 @@ test_N = 512
 sqrtpi2 = 0.88622692545275794
 truevaluepoly = 0.94031597258
 truevaluepoly_caputo = 1.50450555 # 8 / (3 * np.sqrt(np.pi))
+truevaluepoly_caputo_higher = 2 / Gamma(1.5)
 
 INTER = GLIinterpolat(1)
 
@@ -131,9 +132,12 @@ class TestAlgorithms(unittest.TestCase):
 
     def test_CaputoL1point_accuracy_polynomial(self):
         self.assertTrue(abs(CaputoL1point(0.5, lambda x: x**2-1, 0, 1., 1024)-truevaluepoly_caputo) <= 1e-3)
-        
-    def test_CaputoL2Cpoint_accuracy_sqrt(self):
-        self.assertTrue(abs(CaputoL2Cpoint(0.5, lambda x: x**0.5, 0, 1., 1024)-sqrtpi2) <= 1e-1)
+    
+    def test_CaputoL2point_accuracy_polynomial(self):
+        self.assertTrue(abs(CaputoL2point(1.5, lambda x: x**2, 0, 1., 1024)-truevaluepoly_caputo_higher) <= 1e-1)
+
+    def test_CaputoL2Cpoint_accuracy_polynomial_higher(self):
+        self.assertTrue(abs(CaputoL2Cpoint(1.5, lambda x: x**2, 0, 1., 1024)-truevaluepoly_caputo_higher) <= 1e-1)
 
     def test_CaputoL2Cpoint_accuracy_polynomial(self):
         self.assertTrue(abs(CaputoL2Cpoint(0.5, lambda x: x**2, 0, 1., 1024)-truevaluepoly_caputo) <= 1e-3)

--- a/tests/test.py
+++ b/tests/test.py
@@ -130,7 +130,7 @@ class TestAlgorithms(unittest.TestCase):
         self.assertTrue(abs(CaputoL1point(0.5, lambda x: x**0.5, 0, 1., 1024)-sqrtpi2) <= 1e-2)
 
     def test_CaputoL1point_accuracy_polynomial(self):
-        self.assertTrue(abs(CaputoL1point(0.5, lambda x: x**2-1, 0, 1., 1024)-truevaluepoly_caputo) <= 1e-2)
+        self.assertTrue(abs(CaputoL1point(0.5, lambda x: x**2-1, 0, 1., 1024)-truevaluepoly_caputo) <= 1e-3)
         
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)

--- a/tests/test.py
+++ b/tests/test.py
@@ -12,6 +12,7 @@ size_coefficient_array = 20
 test_N = 512
 sqrtpi2 = 0.88622692545275794
 truevaluepoly = 0.94031597258
+truevaluepoly_caputo = 1.50450555 # 8 / (3 * np.sqrt(np.pi))
 
 INTER = GLIinterpolat(1)
 
@@ -124,6 +125,12 @@ class TestAlgorithms(unittest.TestCase):
         
     def test_RL_accuracy_sqrt(self):
         self.assertTrue(abs(RL_result - sqrtpi2) <= 1e-4)
+
+    def test_CaputoL1point_accuracy_sqrt(self):
+        self.assertTrue(abs(CaputoL1point(0.5, lambda x: x**0.5, 0, 1., 1024)-sqrtpi2) <= 1e-2)
+
+    def test_CaputoL1point_accuracy_polynomial(self):
+        self.assertTrue(abs(CaputoL1point(0.5, lambda x: x**2-1, 0, 1., 1024)-truevaluepoly_caputo) <= 1e-2)
         
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
Created functions implementing the Caputo differintegral using the L1 and L2C methods. They aren't extremely precise, though... 

I verified them in the cases of the half derivative of $\sqrt x$, $x^2$, $x^3$, and $x^4$ for $x\in[0.5, 10)$. The L2C method *should* support derivatives of order up to 2, but for some reason it's not accurate at 1.5 yet.

I have added tests which compare the results for a 0.5 order derivative of $\sqrt x$ and $x^2$, and both pass for each function on my Windows 10 machine.