### PR TITLE
Predictor corrector method

### DIFF
--- a/differint/differint.py
+++ b/differint/differint.py
@@ -599,6 +599,7 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
                 initial_value_contribution += initial_values[k] / np.math.factorial(k) * (x_points[x_index + 1] ** k - x_points[x_index] ** k) 
         elif alpha < 1:
             raise ValueError('Not yet supported!')
+        y_prediction[x_index + 1] += initial_value_contribution
         y_prediction[x_index + 1] += y_correction[x_index]
         y_prediction[x_index + 1] += step_size ** alpha / Gamma(alpha + 1) * f_name(x_points[x_index], y_correction[x_index])
         subsum = 0
@@ -611,6 +612,5 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
         y_correction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * alpha * f_name(x_points[x_index], y_correction[x_index])
         y_correction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * f_name(x_points[x_index + 1], y_prediction[x_index + 1])
         y_correction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * subsum
-    y_prediction = y_correction
     
     return y_correction

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -560,7 +560,7 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
     ==========
         initial_values : float 1d-array
             A list of initial values for the IVP. There should be as many IVs
-            as floor(alpha).
+            as ceil(alpha).
         alpha : float
             The order of the differintegral in the equation to be computed.
         f_name : function handle, lambda function, list, or 1d-array of 
@@ -592,10 +592,10 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
     for x_index in range(num_points - 1):
         initial_value_contribution = 0
         if 1 < alpha and alpha < 2:
-            initial_value_contribution = initial_values[0] * step_size
+            initial_value_contribution = initial_values[1] * step_size
         elif 2 < alpha:
-            for k in range(len(initial_values)):
-                initial_value_contribution += initial_values[k] / Gamma(k + 1) * (x_points[x_index + 1] ** (k + 1) - x_points[x_index] ** (k + 1)) 
+            for k in range(1, int(np.ceil(alpha)) - 1):
+                initial_value_contribution += initial_values[k] / np.math.factorial(k) * (x_points[x_index + 1] ** k - x_points[x_index] ** k) 
         elif alpha < 1:
             raise ValueError('Not yet supoprted!')
         y_prediction[x_index + 1] += y_correction[x_index]

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -553,6 +553,8 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
         Baskonus, H.M., Bulut, H. (2015) On the numerical solutions of some fractional
         ordinary differential equations by fractional Adams-Bashforth-Moulton method.
         De Gruyter.
+        Weilbeer, M. (2005) Efficient Numerical Methods for Fractional Differential
+        Equations and their Analytical Background. 
 
 
         

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -603,7 +603,7 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
         if 1 < alpha and alpha < 2:
             initial_value_contribution = initial_values[1] * step_size
         elif 2 < alpha:
-            for k in range(1, int(np.ceil(alpha)) - 1):
+            for k in range(1, int(np.ceil(alpha))):
                 initial_value_contribution += initial_values[k] / np.math.factorial(k) * (x_points[x_index + 1] ** k - x_points[x_index] ** k) 
         elif alpha < 1:
             raise ValueError('Not yet supported!')

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -595,7 +595,7 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
             initial_value_contribution = initial_values[0] * step_size
         elif 2 < alpha:
             for k in range(len(initial_values)):
-                initial_value_contribution += initial_values[i] / Gamma(i + 1) * (x_points[x_index + 1] ** (k + 1) - x_points[x_index] ** (k + 1)) 
+                initial_value_contribution += initial_values[k] / Gamma(k + 1) * (x_points[x_index + 1] ** (k + 1) - x_points[x_index] ** (k + 1)) 
         elif alpha < 1:
             raise ValueError('Not yet supoprted!')
         y_prediction[x_index + 1] += y_correction[x_index]

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -491,7 +491,7 @@ class GLIinterpolat:
         self.prv = alpha*(alpha-2)/8
 
 def PCcoeffs(alpha, j, n):
-    if 1 < alpha and alpha < 2:
+    if 1 < alpha:
         if j == 0:
             return (n+1)**alpha * (alpha - n) + n**alpha * (2 * n - alpha - 1) - (n - 1)**(alpha + 1)
         elif j == n:
@@ -533,29 +533,32 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
     """
     x_points = np.linspace(domain_start, domain_end, num_points)
     step_size = x_points[1] - x_points[0]
-    if 1 < alpha and alpha < 2:
-        y_prediction = np.zeros(num_points)
-        y_prediction[0] = initial_values[0]            
-        y_correction = np.zeros(num_points)
-        y_correction[0] = initial_values[0]
-        
-        for x_index in range(num_points - 1):
-            y_prediction[x_index + 1] += initial_values[0] * step_size
-            y_prediction[x_index + 1] += y_correction[x_index]
-            y_prediction[x_index + 1] += step_size ** alpha / Gamma(alpha + 1) * f_name(x_points[x_index], y_correction[x_index])
-            subsum = 0
-            for j in range(x_index + 1):
-                subsum += PCcoeffs(alpha, j, x_index) * f_name(x_points[j], y_correction[j])
-            y_prediction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * subsum
+    y_correction = np.zeros(num_points)
+    y_prediction = np.zeros(num_points)
+    
+    y_prediction[0] = initial_values[0]            
+    y_correction[0] = initial_values[0]
+    for x_index in range(num_points - 1):
+        initial_value_contribution = 0
+        if 1 < alpha and alpha < 2:
+            initial_value_contribution = initial_values[0] * step_size
+        elif 2 < alpha:
+            for k in range(len(initial_values)):
+                initial_value_contribution += initial_values[i] / Gamma(i + 1) * (x_points[x_index + 1] ** (k + 1) - x_points[x_index] ** (k + 1)) 
+        elif alpha < 1:
+            raise ValueError('Not yet supoprted!')
+        y_prediction[x_index + 1] += y_correction[x_index]
+        y_prediction[x_index + 1] += step_size ** alpha / Gamma(alpha + 1) * f_name(x_points[x_index], y_correction[x_index])
+        subsum = 0
+        for j in range(x_index + 1):
+            subsum += PCcoeffs(alpha, j, x_index) * f_name(x_points[j], y_correction[j])
+        y_prediction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * subsum
 
-            y_correction[x_index + 1] += initial_values[0] * step_size
-            y_correction[x_index + 1] += y_correction[x_index]
-            y_correction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * alpha * f_name(x_points[x_index], y_correction[x_index])
-            y_correction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * f_name(x_points[x_index + 1], y_prediction[x_index + 1])
-            y_correction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * subsum
-        y_prediction = y_correction
-    elif 2 < alpha:
-        raise ValueError('Not yet supported!')
-    elif alpha < 1:
-        raise ValueError('Not yet supoprted!')
+        y_correction[x_index + 1] += initial_value_contribution
+        y_correction[x_index + 1] += y_correction[x_index]
+        y_correction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * alpha * f_name(x_points[x_index], y_correction[x_index])
+        y_correction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * f_name(x_points[x_index + 1], y_prediction[x_index + 1])
+        y_correction[x_index + 1] += step_size ** alpha / Gamma(alpha + 2) * subsum
+    y_prediction = y_correction
+    
     return y_correction

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -503,7 +503,15 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
         method, modified to be compatible with fractional derivatives.
 
     see Deng, W. (2007) Short memory principle and a predictor–corrector approach for 
-    fractional differential equations. Journal of Computational and Applied Mathematics.
+        fractional differential equations. Journal of Computational and Applied 
+        Mathematics.
+
+    test examples from
+        Baskonus, H.M., Bulut, H. (2015) On the numerical solutions of some fractional
+        ordinary differential equations by fractional Adams-Bashforth-Moulton method.
+        De Gruyter.
+
+
         
     Parameters
     ==========

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -582,6 +582,14 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
         y_correction : float 1d-array
             The calculated solution to the IVP at each of the points 
             between the left and right endpoint.
+
+    Examples:
+        >>> f_name = lambda x, y : y - x - 1
+        >>> initial_values = [1, 0]
+        >>> y_solved = PCsolver(initial_values, 1.5, f_name)
+        >>> theoretical = np.linspace(0, 1, 100) + 1
+        >>> np.allclose(y_solved, theoretical)
+        True
     """
     x_points = np.linspace(domain_start, domain_end, num_points)
     step_size = x_points[1] - x_points[0]

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -586,8 +586,8 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
     """
     x_points = np.linspace(domain_start, domain_end, num_points)
     step_size = x_points[1] - x_points[0]
-    y_correction = np.zeros(num_points)
-    y_prediction = np.zeros(num_points)
+    y_correction = np.zeros(num_points, dtype='complex_')
+    y_prediction = np.zeros(num_points, dtype='complex_')
     
     y_prediction[0] = initial_values[0]            
     y_correction[0] = initial_values[0]

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -145,6 +145,49 @@ def Beta(x,y):
     
     return Gamma(x)*Gamma(y)/Gamma(x+y)
     
+def MittagLeffler(a, b, x, num_terms=50, *, ignore_special_cases=False):
+    ''' Calculate the Mittag-Leffler function by checking for special cases, and trying to 
+        reduce the parameters. If neither of those work, it just brute forces it.
+        
+        Parameters
+       ==========
+        a : float
+            The first parameter of the Mittag-Leffler function.
+        b : float
+            The second parameter of the Mittag-Leffler function
+        x : float or 1D-array of floats
+            The value or values to be evaluated at.
+        num_terms : int
+            The number of terms to calculate in the sum. Ignored if 
+            a special case can be used instead. Default value is 100.
+        ignore_special_cases : bool
+            Don't use the special cases, use the series definition.
+            Probably only useful for testing. Default value is False.
+    '''
+    # check for quick special cases
+    if not ignore_special_cases:
+        if a == 0:
+            if (np.abs(x) < 1).all():
+                return 1 / Gamma(b) * 1 / (1 - x)
+            return x * np.inf
+        elif a == 0.5 and b == 1:
+            # requires calculation of the complementary error function
+            pass
+        elif a == 1 and b == 1:
+            return np.exp(x)
+        elif a == 2 and b == 1:
+            return np.cosh(np.sqrt(x))
+        elif a == 1 and b == 2:
+            return (np.exp(x) - 1) / x
+        elif a == 2 and b == 2:
+            return np.sinh(np.sqrt(x)) / np.sqrt(x)
+    # manually calculate with series definition
+    exponents = np.arange(num_terms)
+    exp_vals = np.array([x]).T ** exponents
+    gamma_vals = np.array([Gamma(exponent * a + b) for exponent in exponents])
+    return np.sum(exp_vals / gamma_vals, axis=1)
+
+
 def GLcoeffs(alpha,n):
     """ Computes the GL coefficient array of size n. 
     

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -565,8 +565,7 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
             as ceil(alpha).
         alpha : float
             The order of the differintegral in the equation to be computed.
-        f_name : function handle, lambda function, list, or 1d-array of 
-                 function values
+        f_name : function handle or lambda function
             This is the function on the right side of the equation, and should
             accept two variables; first the independant variable, and second
             the equation to be solved.

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -585,7 +585,7 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
 
     Examples:
         >>> f_name = lambda x, y : y - x - 1
-        >>> initial_values = [1, 0]
+        >>> initial_values = [1, 1]
         >>> y_solved = PCsolver(initial_values, 1.5, f_name)
         >>> theoretical = np.linspace(0, 1, 100) + 1
         >>> np.allclose(y_solved, theoretical)

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -599,7 +599,7 @@ def PCsolver(initial_values, alpha, f_name, domain_start=0, domain_end=1, num_po
             for k in range(1, int(np.ceil(alpha)) - 1):
                 initial_value_contribution += initial_values[k] / np.math.factorial(k) * (x_points[x_index + 1] ** k - x_points[x_index] ** k) 
         elif alpha < 1:
-            raise ValueError('Not yet supoprted!')
+            raise ValueError('Not yet supported!')
         y_prediction[x_index + 1] += y_correction[x_index]
         y_prediction[x_index + 1] += step_size ** alpha / Gamma(alpha + 1) * f_name(x_points[x_index], y_correction[x_index])
         subsum = 0

--- a/tests/test.py
+++ b/tests/test.py
@@ -164,6 +164,10 @@ class TestSolvers(unittest.TestCase):
         ML_alpha = MittagLeffler(5.5, 1, xs)
         self.assertTrue((np.abs(PCsolver([1, 0, 0, 0, 0, 0], 5.5, lambda x,y : y)-ML_alpha) <= 1e-2).all())
 
+    def test_PC_solution_linear(self):
+        xs = np.linspace(0, 1, 100)
+        self.assertTrue((np.abs(PCsolver([1, 0], 1.5, lambda x,y : y-x-1)-(xs+1)) <= 1e-2).all())
+
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)
     

--- a/tests/test.py
+++ b/tests/test.py
@@ -166,7 +166,7 @@ class TestSolvers(unittest.TestCase):
 
     def test_PC_solution_linear(self):
         xs = np.linspace(0, 1, 100)
-        self.assertTrue((np.abs(PCsolver([1, 0], 1.5, lambda x,y : y-x-1)-(xs+1)) <= 1e-2).all())
+        self.assertTrue((np.abs(PCsolver([1, 1], 1.5, lambda x,y : y-x-1)-(xs+1)) <= 1e-2).all())
 
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)

--- a/tests/test.py
+++ b/tests/test.py
@@ -93,6 +93,23 @@ class HelperTestCases(unittest.TestCase):
 
     def testComplexValue(self):
         self.assertEqual(np.round(Gamma(1j), 4), -0.1549-0.498j)
+
+    """ Unit tests for Mittag-Leffler function. """
+
+    def test_ML_cosh_root(self):
+        xs = np.arange(10, 0.1)
+        self.assertTrue((np.abs(MittagLeffler(2, 1, xs, ignore_special_cases=True)\
+                                        - np.cosh(np.sqrt(xs))) <= 1e-3).all())
+
+    def test_ML_exp(self):
+        xs = np.arange(10, 0.1)
+        self.assertTrue((np.abs(MittagLeffler(1, 1, xs, ignore_special_cases=True)\
+                                        - np.exp(xs)) <= 1e-3).all())
+
+    def test_ML_geometric(self):
+        xs = np.arange(1, 0.05)
+        self.assertTrue((np.abs(MittagLeffler(0, 1, xs, ignore_special_cases=True)\
+                                        - 1 / (1 - xs)) <= 1e-3).all())
         
 class TestInterpolantCoefficients(unittest.TestCase):
     """ Test the correctness of the interpolant coefficients. """

--- a/tests/test.py
+++ b/tests/test.py
@@ -162,7 +162,7 @@ class TestSolvers(unittest.TestCase):
     def test_PC_solution_ML(self):
         xs = np.linspace(0, 1, 100)
         ML_alpha = MittagLeffler(5.5, 1, xs)
-        self.assertTrue((np.abs(PCsolver([1, 0, 0, 0, 0, 0], 5.5, lambda x,y : y)-ML_alpha) <= 1e-2).all())
+        self.assertTrue((np.abs(PCsolver([1, 0, 0, 0, 0, 0], 5.5, PC_func_ML)-ML_alpha) <= 1e-2).all())
 
     def test_PC_solution_linear(self):
         xs = np.linspace(0, 1, 100)

--- a/tests/test.py
+++ b/tests/test.py
@@ -161,7 +161,7 @@ class TestSolvers(unittest.TestCase):
 
     def test_PC_solution_ML(self):
         xs = np.linspace(0, 1, 100)
-        ML_alpha = MittagLeffler(5.5, 1, xs)
+        ML_alpha = MittagLeffler(5.5, 1, xs ** 5.5)
         self.assertTrue((np.abs(PCsolver([1, 0, 0, 0, 0, 0], 5.5, PC_func_ML)-ML_alpha) <= 1e-2).all())
 
     def test_PC_solution_linear(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -12,6 +12,7 @@ size_coefficient_array = 20
 test_N = 512
 sqrtpi2 = 0.88622692545275794
 truevaluepoly = 0.94031597258
+PC_x_power = np.linspace(0, 1, 100) ** 5.5
 
 INTER = GLIinterpolat(1)
 
@@ -32,6 +33,9 @@ GLI_length = len(GLI_r)
 RL_r = RL(0.5, lambda x: np.sqrt(x), 0, 1, test_N)
 RL_result = RL_r[-1]
 RL_length = len(RL_r)
+
+# Get FODE function for solving.
+PC_func = lambda x, y : 1/24 * Gamma(5 + 1.5) * x**4 + x**(8 + 2 * 1.5) - y**2
 
 class HelperTestCases(unittest.TestCase):
     """ Tests for helper functions. """
@@ -131,7 +135,12 @@ class TestAlgorithms(unittest.TestCase):
         
     def test_RL_accuracy_sqrt(self):
         self.assertTrue(abs(RL_result - sqrtpi2) <= 1e-4)
-        
+
+class TestSolvers(unittest.TestCase):
+    """ Tests for the correct solution to the equations. """
+    def test_PC_solution_three_halves(self):
+        self.assertTrue((abs(PCsolver([0], 1.5, PC_func, 0, 1, 100)-PC_x_power) <= 1e-2).all())
+
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)
     

--- a/tests/test.py
+++ b/tests/test.py
@@ -156,7 +156,7 @@ class TestAlgorithms(unittest.TestCase):
 class TestSolvers(unittest.TestCase):
     """ Tests for the correct solution to the equations. """
     def test_PC_solution_three_halves(self):
-        self.assertTrue((abs(PCsolver([0], 1.5, PC_func, 0, 1, 100)-PC_x_power) <= 1e-2).all())
+        self.assertTrue((np.abs(PCsolver([0, 0], 1.5, PC_func_power, 0, 1, 100)-PC_x_power) <= 1e-2).all())
 
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)

--- a/tests/test.py
+++ b/tests/test.py
@@ -35,7 +35,8 @@ RL_result = RL_r[-1]
 RL_length = len(RL_r)
 
 # Get FODE function for solving.
-PC_func = lambda x, y : 1/24 * Gamma(5 + 1.5) * x**4 + x**(8 + 2 * 1.5) - y**2
+PC_func_power = lambda x, y : 1/24 * Gamma(5 + 1.5) * x**4 + x**(8 + 2 * 1.5) - y**2
+PC_func_ML = lambda x,y : y
 
 class HelperTestCases(unittest.TestCase):
     """ Tests for helper functions. """
@@ -157,6 +158,11 @@ class TestSolvers(unittest.TestCase):
     """ Tests for the correct solution to the equations. """
     def test_PC_solution_three_halves(self):
         self.assertTrue((np.abs(PCsolver([0, 0], 1.5, PC_func_power, 0, 1, 100)-PC_x_power) <= 1e-2).all())
+
+    def test_PC_solution_ML(self):
+        xs = np.linspace(0, 1, 100)
+        ML_alpha = MittagLeffler(5.5, 1, xs)
+        self.assertTrue((np.abs(PCsolver([1, 0, 0, 0, 0, 0], 5.5, lambda x,y : y)-ML_alpha) <= 1e-2).all())
 
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
Added an implementation of the predictor-corrector method, tailored to solve fractional ODEs of the form ${}^CD^\alpha y(x) = f(x, y(x))$. It supports $\alpha \in (1, \inf)$ (except natural numbers). 

Since it arises fairly commonly in the solution of FODEs, I added an implementation of the two parameter Mittag-Leffler function. 

I also added tests for the $\alpha=1.5$ and $\alpha=5.5$ cases for the solver, and tests for the Mittag-Leffler function. 

This should close #6 as well.