### PR TITLE
Check values compatibility

### DIFF
--- a/differint/differint.py
+++ b/differint/differint.py
@@ -16,7 +16,7 @@ def isPositiveInteger(n):
 def checkValues(alpha, domain_start, domain_end, num_points):
     """ Type checking for valid inputs. """
     
-    assert type(num_points) is type(1), "num_points is not an integer: %r" % num_points
+    assert isPositiveInteger(num_points), "num_points is not an integer: %r" % num_points
     
     assert isinstance(domain_start, (int, np.integer, float, np.floating)),\
                      "domain_start must be integer or float: %r" % domain_start

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -18,14 +18,11 @@ def checkValues(alpha, domain_start, domain_end, num_points):
     
     assert type(num_points) is type(1), "num_points is not an integer: %r" % num_points
     
-    assert type(domain_start) is type(0.0) \
-        or type(domain_start) is type(0), "domain_start must be integer or float: %r" % domain_start
+    assert isinstance(domain_start, (int, np.integer, float, np.floating)),\
+                     "domain_start must be integer or float: %r" % domain_start
         
-    assert type(domain_end) is type(0.0) \
-        or type(domain_end) is type(0), "domain_end must be integer or float: %r" % domain_end
-        
-    # Currently there is no support for complex orders (17 Jan 2018).
-    assert type(alpha) is not type(1+1j), "alpha must be real: %r" % alpha
+    assert isinstance(domain_end, (int, np.integer, float, np.floating)),\
+                     "domain_end must be integer or float: %r" % domain_end
     
     return   
 

--- a/differint/differint.py
+++ b/differint/differint.py
@@ -13,7 +13,7 @@ def isInteger(n):
 def isPositiveInteger(n):
     return isInteger(n) and n > 0
 
-def checkValues(alpha, domain_start, domain_end, num_points):
+def checkValues(alpha, domain_start, domain_end, num_points, support_complex_alpha=False):
     """ Type checking for valid inputs. """
     
     assert isPositiveInteger(num_points), "num_points is not an integer: %r" % num_points
@@ -23,6 +23,9 @@ def checkValues(alpha, domain_start, domain_end, num_points):
         
     assert isinstance(domain_end, (int, np.integer, float, np.floating)),\
                      "domain_end must be integer or float: %r" % domain_end
+
+    if not support_complex_alpha:
+        assert not isinstance(alpha, complex), "Complex alpha not supported for this algorithm."
     
     return   
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -77,7 +77,9 @@ class HelperTestCases(unittest.TestCase):
     def test_checkValues(self):
         with self.assertRaises(AssertionError):
             checkValues(0.1, 0, 1, 1.1)
+        with self.assertRaises(AssertionError):
             checkValues(0.1, 1j, 2, 100)
+        with self.assertRaises(AssertionError):
             checkValues(0.1, 1, 2j, 100)
             
     """ Unit tests for gamma function. """

--- a/tests/test.py
+++ b/tests/test.py
@@ -83,7 +83,10 @@ class HelperTestCases(unittest.TestCase):
             checkValues(0.1, 1, 2j, 100)
         with self.assertRaises(AssertionError):
             checkValues(0.1, 0, 1, -100)
-        alpha_vals = np.array([0.1, 0.2, 10.+2j])
+        with self.assertRaises(AssertionError):
+            checkValues(1+1j, 0, 1, 100)
+        checkValues(1+1j, 0, 1, 100, support_complex_alpha=True)
+        alpha_vals = np.array([0.1, 0.2])
         domain_vals = np.array([0.1, 1, 2.0, -1])
         num_vals = np.array([1., 100.0])
         [[[[checkValues(alpha, domain_start, domain_end, num_points) for alpha in alpha_vals] 

--- a/tests/test.py
+++ b/tests/test.py
@@ -81,6 +81,8 @@ class HelperTestCases(unittest.TestCase):
             checkValues(0.1, 1j, 2, 100)
         with self.assertRaises(AssertionError):
             checkValues(0.1, 1, 2j, 100)
+        with self.assertRaises(AssertionError):
+            checkValues(0.1, 0, 1, -100)
             
     """ Unit tests for gamma function. """
     

--- a/tests/test.py
+++ b/tests/test.py
@@ -79,7 +79,6 @@ class HelperTestCases(unittest.TestCase):
             checkValues(0.1, 0, 1, 1.1)
             checkValues(0.1, 1j, 2, 100)
             checkValues(0.1, 1, 2j, 100)
-            checkValues(1+1j, 1, 2, 100)
             
     """ Unit tests for gamma function. """
     

--- a/tests/test.py
+++ b/tests/test.py
@@ -85,6 +85,7 @@ class HelperTestCases(unittest.TestCase):
             checkValues(0.1, 0, 1, -100)
         with self.assertRaises(AssertionError):
             checkValues(1+1j, 0, 1, 100)
+        checkValues(0.5, 0, 1, 100, support_complex_alpha=True)
         checkValues(1+1j, 0, 1, 100, support_complex_alpha=True)
         alpha_vals = np.array([0.1, 0.2])
         domain_vals = np.array([0.1, 1, 2.0, -1])

--- a/tests/test.py
+++ b/tests/test.py
@@ -83,6 +83,13 @@ class HelperTestCases(unittest.TestCase):
             checkValues(0.1, 1, 2j, 100)
         with self.assertRaises(AssertionError):
             checkValues(0.1, 0, 1, -100)
+        alpha_vals = np.array([0.1, 0.2, 10.+2j])
+        domain_vals = np.array([0.1, 1, 2.0, -1])
+        num_vals = np.array([1., 100.0])
+        [[[[checkValues(alpha, domain_start, domain_end, num_points) for alpha in alpha_vals] 
+                                                                     for domain_start in domain_vals] 
+                                                                     for domain_end in domain_vals]
+                                                                     for num_points in num_vals]
             
     """ Unit tests for gamma function. """
     


### PR DESCRIPTION
Currently the check values function doesn't support numpy types, making it difficult to use numpy arrays as inputs into functions... Now support for numpy types have been added. Also, support for complex alpha value has been added previously, so it is no longer necessary to check for that case.

I've added tests that are expected to pass along with the ones expected to raise errors. Also, the current implementation checks if _any_ of the `checkValues` calls raises an error, I've changed it to expect an error from each call.