### PR TITLE
Remove misplaced version number

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,7 @@
 name: differint
 
 on:
-  release: 0.4.0
+  release:
     types: [published]
 
 permissions:


### PR DESCRIPTION
Now the action should no longer have an error (except for the api key not being on the repo yet)